### PR TITLE
Deterministic E2E testing: seeded RNG + fixed-timestep stepping

### DIFF
--- a/.claude/skills/e2e/SKILL.md
+++ b/.claude/skills/e2e/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: e2e
-description: Write, debug, or update Playwright E2E tests for the game
+description: Write, debug, or update Playwright E2E tests for the game — including fast, frame-exact deterministic tests using seeded RNG and fixed-timestep stepping.
 user-invocable: true
 allowed-tools: Bash, Read, Edit, Write, Grep, Glob
 argument-hint: "[test-name or 'debug' or 'update-baselines']"
@@ -12,88 +12,173 @@ Work with Playwright E2E tests for this canvas game. The argument ($ARGUMENTS) d
 - **`debug`**: Diagnose why E2E tests are failing
 - **`update-baselines`**: Regenerate visual screenshot baselines
 
+## Toolchain (keep current)
+
+- **Node 24 LTS**, **pnpm 11**, **Playwright 1.59**, Vite 7, Vitest 4.
+- `package.json` pins `packageManager` (pnpm@11.x) and `engines.node >=24`.
+- If `node -v` is wrong in a shell: `source "$NVM_DIR/nvm.sh" && nvm use 24`.
+- Playwright 1.57+ runs **Chrome for Testing**, not Chromium. If a browser is missing:
+  `npx playwright install chrome-for-testing chromium-headless-shell`.
+- Run E2E: `pnpm run e2e` (headless, CI mode) — see Commands below.
+
 ## Architecture
 
 ```
 e2e/
   playwright.config.ts        # Config: Chromium, 1920x1080, webServer on :3000
-  fixtures/game.fixture.ts    # GameHelpers: waitForState, waitForEnemies, freezeStarfield, etc.
+  fixtures/game.fixture.ts    # GameHelpers: waitForState, stepFrames, seedRandom, etc.
   helpers/game-bridge.ts      # TypeScript types for window.__GAME__ bridge API
   tests/*.spec.ts             # Test files
   tests/*.spec.ts-snapshots/  # Visual baselines (platform-specific PNGs)
 
 src/testing/e2eTestBridge.ts  # Bridge installed in dev mode — exposes game state on window.__GAME__
+src/utils/gameplayRng.ts      # Seeded gameplay RNG — the seam that makes runs reproducible
 ```
 
-## Writing a New Test
+## Two ways to write a test
 
-1. Read `e2e/fixtures/game.fixture.ts` to understand available helpers
-2. Read `e2e/helpers/game-bridge.ts` for the full bridge API
-3. Read an existing test in `e2e/tests/` for patterns
-4. Write test using the `test` and `expect` from `../fixtures/game.fixture`
-5. Use `game.freezeStarfield()` before any screenshot
-6. Use generous timeouts (10s+ for state waits, 20s+ for enemy spawns)
-7. Add timing-chain comments when chaining waits: `// Xa + Yb = Z < test timeout`
+### A. Deterministic (preferred for gameplay logic) — fast, frame-exact
 
-### Key Patterns
+Use `seedRandom()` + `startDeterministic()` + `stepFrames()`. The simulation
+advances by a fixed number of fixed-delta frames, decoupled from the wall
+clock, so **30 simulated seconds run in milliseconds** and produce the **same
+result every run**. Assert on exact state — no `toBeGreaterThan`, no generous
+timeouts. Reference: `e2e/tests/deterministic-gameplay.spec.ts`.
 
 ```typescript
 import { test, expect } from '../fixtures/game.fixture';
 
-test('example', async ({ page, game }) => {
+test('seeded battle is reproducible', async ({ page, game }) => {
+  async function run(seed: number) {
+    await page.goto('/');
+    await game.waitForGameReady();
+    await game.seedRandom(seed);          // seed BEFORE startDeterministic
+    await game.startDeterministic();      // starts game + freezes the wall-clock ticker
+    await page.evaluate(() => {            // disable AI for byte-exact runs (see caveat)
+      if (window.__GAME__.isAIEnabled()) window.__GAME__.toggleAI();
+    });
+    await game.waitForState('PLAYING');
+    await page.evaluate(() => window.__GAME__.setResources(99999));
+    await page.evaluate(() => window.__GAME__.placeTurret(1, 960, 340));
+    await game.stepFrames(1800);          // advance exactly 1800 frames (30s @ 60fps)
+    return game.getSnapshot();
+  }
+  expect(await run(424242)).toEqual(await run(424242));
+});
+```
+
+**Rules for deterministic tests:**
+- Call `seedRandom(seed)` *before* `startDeterministic()` — wave 1 spawns during start.
+- Use `startDeterministic()`, not `startGame()` — it freezes the ticker so no
+  variable number of real frames tick between async test steps.
+- The sim only advances via `stepFrames(n)`. Setup calls (`setResources`,
+  `placeTurret`, `freezeStarfield`) are safe between steps — the sim is frozen.
+- **Caveat — the AI Commander.** Autoplay is ON by default and its economic
+  micro-decisions carry residual nondeterminism. For *byte-exact* reproducibility
+  disable it (`toggleAI()`). Core simulation (spawns, combat, kills, health,
+  waves) is fully deterministic with AI off. Cover the AI path separately with
+  loose-bound assertions.
+
+### B. Wall-clock (for menu/UI flows that can't be stepped)
+
+The classic approach — `startGame()`, then wait for real time. Needs generous
+timeouts. Use only when deterministic stepping doesn't fit (e.g. testing the
+real-time loop, input handling, or menu transitions).
+
+```typescript
+test('wave 1 spawns enemies', async ({ page, game }) => {
   await page.goto('/');
   await game.waitForGameReady();
   await game.startGame();
   await game.waitForState('PLAYING');
-
-  // Use bridge for game manipulation (prefer over raw clicks)
-  await page.evaluate(() => window.__GAME__.toggleGodMode());
-  await page.evaluate(() => window.__GAME__.setResources(5000));
-  await page.evaluate(() => window.__GAME__.placeTurret(1, 960, 540));
-
-  // Wait for game events
-  await page.waitForFunction(
-    () => window.__GAME__.getEventsByType('ENEMY_KILLED').length > 0,
-    { timeout: 45000 }
-  );
+  await game.waitForEnemies(20000);       // SwiftShader on CI is ~5x slower
+  expect((await game.getSnapshot()).activeEnemies).toBeGreaterThan(0);
 });
 ```
 
+## Writing a New Test — checklist
+
+1. Read `e2e/fixtures/game.fixture.ts` for available helpers.
+2. Read `e2e/helpers/game-bridge.ts` for the full bridge API.
+3. Read `e2e/tests/deterministic-gameplay.spec.ts` (deterministic) or
+   `e2e/tests/gameplay.spec.ts` (wall-clock) for patterns.
+4. Prefer approach **A** for anything testing gameplay/simulation outcomes.
+5. `import { test, expect } from '../fixtures/game.fixture'`.
+6. `game.freezeStarfield()` before any screenshot.
+7. For wall-clock waits: generous timeouts (10s+ state, 20s+ enemies) and add
+   timing-chain comments: `// 20s enemies + 45s kills = 65s < 90s test timeout`.
+
+## Bridge API (window.__GAME__)
+
+Source of truth: `src/testing/e2eTestBridge.ts`. Key methods:
+
+| Method | Purpose |
+|---|---|
+| `isReady()` | True once the game is initialized |
+| `startGame()` | Start a game (wall-clock ticker runs) |
+| `startDeterministic()` | Start a game with the ticker **frozen** — advance only via `stepFrames()` |
+| `seedRandom(seed)` | Seed the gameplay RNG (mulberry32) — makes spawns/combat reproducible |
+| `stepFrames(n, deltaMs?)` | Advance exactly `n` fixed-delta frames (default 1/60s) |
+| `pause()` / `resume()` / `restart()` | Lifecycle |
+| `getSnapshot()` | `{ state, wave, waveState, activeEnemies, resources, score, kmHealth, kmMaxHealth }` |
+| `getEvents()` / `getEventsByType(t)` / `clearEvents()` | Captured event log |
+| `getEntityCounts()` | `{ turrets, enemies }` |
+| `setResources(n)` / `setKMHealth(n)` / `placeTurret(type,x,y)` | State manipulation |
+| `toggleGodMode()` / `toggleAI()` / `isAIEnabled()` | Cheats / AI control |
+| `freezeStarfield()` | Freeze the animated starfield before screenshots |
+
 ### If You Need New Bridge Methods
-1. Add to `src/testing/e2eTestBridge.ts` (the `window.__GAME__` object)
-2. Add type to `e2e/helpers/game-bridge.ts` (`GameBridge` interface)
-3. Add helper to `e2e/fixtures/game.fixture.ts` (`GameHelpers` interface + implementation)
+Keep all three layers in sync:
+1. `src/testing/e2eTestBridge.ts` — the `window.__GAME__` object
+2. `e2e/helpers/game-bridge.ts` — the `GameBridge` interface
+3. `e2e/fixtures/game.fixture.ts` — the `GameHelpers` interface + implementation
+
+## How determinism works (so you can extend it)
+
+- `src/utils/gameplayRng.ts` — a seeded mulberry32 stream. Unseeded it falls
+  back to `Math.random()`, so production behaviour is unchanged.
+- Gameplay-affecting RNG (enemy spawns, speeds, variant rolls, ability rolls,
+  status procs, AI humanization) calls `randomFloat()` from this module.
+  Rendering/particle randomness deliberately stays on `Math.random()` so visual
+  effects can never desync the simulation.
+- `GameLoopManager.step()` runs the update phases with a fixed delta;
+  `Game.stepFrames()` stops the wall-clock ticker and steps.
+- **If you add new gameplay randomness, import `randomFloat` from `../utils`** —
+  not `Math.random()` — or you reintroduce nondeterminism.
+
+## Commands
+
+```bash
+pnpm run e2e            # Headless (CI mode) — default
+pnpm run e2e:headed     # Watch in a visible browser
+pnpm run e2e:ui         # Interactive Playwright UI
+pnpm run e2e:update     # Regenerate visual baselines
+# Single spec:
+npx playwright test --config e2e/playwright.config.ts deterministic-gameplay
+```
 
 ## Debugging Failures
 
-1. Run `pnpm run e2e:headed` to watch in browser
-2. Check `e2e/test-results/` for failure screenshots
+1. `pnpm run e2e:headed` to watch in browser, or `npx playwright test ... --workers=1`.
+2. Check `e2e/test-results/` for failure screenshots + traces.
 3. Common causes:
-   - **Timeout**: Increase wait timeout or check if game state transition is broken
-   - **Visual diff**: Starfield not frozen, or baselines stale — run `pnpm run e2e:update`
-   - **Platform mismatch**: Visual baselines are `*-chromium-darwin.png` — CI generates `*-chromium-linux.png`. Visual tests skip on CI
-   - **Turret placement miss**: Enemies spawn from random edges — use cardinal positions around (960, 540) with high-range turrets (torpedo type 1)
+   - **Nondeterministic deterministic test**: did you `seedRandom()` *before*
+     `startDeterministic()`? Is the AI disabled? Did new code call
+     `Math.random()` instead of `randomFloat()` in a gameplay path?
+   - **Timeout** (wall-clock tests): increase wait or check state transition.
+   - **Visual diff**: starfield not frozen, or baselines stale (`pnpm run e2e:update`).
+   - **Platform mismatch**: baselines are `*-chromium-darwin.png`; CI is
+     `*-chromium-linux.png`. Visual tests skip on CI.
+   - **Turret placement miss**: enemies spawn from random edges — use cardinal
+     positions around (960, 540) with torpedo turrets (type 1).
 
-## Updating Visual Baselines
+## Reference
 
-```bash
-pnpm run e2e:update           # Regenerate all baselines
-pnpm run e2e:update -- --grep visual  # Only visual tests
-pnpm run e2e                  # Verify baselines match
-```
+| Turret | Type | Range | Damage | Notes |
+|---|---|---|---|---|
+| Phaser | 0 | 200px | 10 | Short range |
+| Torpedo | 1 | 350px | 60 | Best for tests |
+| Beam | 2 | 250px | 30 | Continuous |
 
-After updating, run `pnpm run e2e` at least 2-3 times to confirm repeatability.
-
-## Turret Types Quick Reference
-
-| Type | Name    | Range | Damage | Notes                    |
-|------|---------|-------|--------|--------------------------|
-| 0    | Phaser  | 200px | 10     | Short range, low damage  |
-| 1    | Torpedo | 350px | 60     | Best for E2E tests       |
-| 2    | Beam    | 250px | 30     | Continuous damage         |
-
-## Game States
-
-`MENU` → `PLAYING` → `PAUSED` / `GAME_OVER`
-
-KM center is at world coordinates (960, 540) on a 1920x1080 canvas.
+Game states: `MENU` → `PLAYING` → `PAUSED` / `GAME_OVER`.
+KM center is world (960, 540) on a 1920×1080 canvas.

--- a/.claude/skills/visual-check/SKILL.md
+++ b/.claude/skills/visual-check/SKILL.md
@@ -61,14 +61,17 @@ Used when MCP is not installed (and you don't want to ask the user to install it
 ## Preflight (run in order)
 
 1. **Path selection** — `claude mcp list 2>/dev/null | grep -i playwright`. If found → Path A (MCP). Else → Path B (script).
-2. **Dev server up on :3000?** — `curl -s -o /dev/null -w "%{http_code}" http://localhost:3000` should return 200. If not, start it in background:
+2. **Node 24 LTS** — pnpm 11 requires it. `node -v`. If wrong, `source "$NVM_DIR/nvm.sh" && nvm use 24` (install with `nvm install 24 --lts`). `package.json` pins `engines.node >=24` and `packageManager: pnpm@11.x`.
+3. **Dev server up on :3000?** — `curl -s -o /dev/null -w "%{http_code}" http://localhost:3000` should return 200. If not, start it in background:
    ```bash
-   cd /Users/chayut/repos/kobayashi-maru && pnpm run dev
+   source "$NVM_DIR/nvm.sh" && nvm use 24 && cd /Users/chayut/repos/kobayashi-maru && pnpm run dev
    ```
    (Bash `run_in_background: true`, then poll until 200.)
-3. **Path B only — Node ≥ 22.13** — pnpm 10 requires it. `node --version`. If lower, `source ~/.nvm/nvm.sh && nvm use 22.13` (install with `nvm install 22.13` if missing).
-4. **Path B only — project install fresh?** — `pnpm install --frozen-lockfile`. No-op if up to date.
-5. **Path B only — Playwright browsers cached?** — `pnpm exec playwright install chromium` (~300MB one-time download into `~/Library/Caches/ms-playwright/`). Skip if `ls ~/Library/Caches/ms-playwright/ | grep -q chromium`.
+4. **Path B only — project install fresh?** — `pnpm install`. No-op if up to date.
+5. **Playwright browser cached?** — Playwright 1.57+ uses **Chrome for Testing**, not Chromium.
+   - Path A (MCP): `npx @playwright/mcp@latest install-browser chrome-for-testing`
+   - Path B (script): `npx playwright install chromium chromium-headless-shell`
+   One-time ~100MB download into `~/Library/Caches/ms-playwright/`.
 6. **Bridge present** — verify `window.__GAME__?.isReady()` resolves before driving the game (Path A: `browser_evaluate`. Path B: `await page.waitForFunction(...)`). The bridge is dev-mode only — see `src/testing/e2eTestBridge.ts`.
 
 If any preflight step fails, **report it and stop** — don't paper over it.
@@ -149,14 +152,48 @@ Available in dev mode. See `src/testing/e2eTestBridge.ts` for source of truth.
 |---|---|
 | `isReady()` | Returns true once game is initialized |
 | `startGame()` / `pause()` / `resume()` / `restart()` | Game lifecycle |
+| `startDeterministic()` | Start a game with the wall-clock ticker **frozen** — advance only via `stepFrames()` |
+| `seedRandom(seed)` | Seed the gameplay RNG — makes spawns/combat reproducible |
+| `stepFrames(n, deltaMs?)` | Advance exactly `n` fixed-delta frames (default 1/60s) |
 | `getSnapshot()` | `{ state, wave, waveState, activeEnemies, resources, score, kmHealth, kmMaxHealth }` |
 | `setResources(amount)` | Force-set player resources |
 | `setKMHealth(health)` | Force-set Kobayashi Maru hull health |
 | `placeTurret(type, x, y)` | Place a turret. type 0=phaser, 1=torpedo. world coords (KM at 960,540) |
-| `toggleGodMode()` / `toggleAI()` | Cheats |
+| `toggleGodMode()` / `toggleAI()` / `isAIEnabled()` | Cheats / AI control |
 | `freezeStarfield()` | **ALWAYS call this before screenshots** — animated starfield otherwise causes spurious diffs |
 | `getEvents()` / `getEventsByType(type)` / `clearEvents()` | Captured event log |
 | `getEntityCounts()` | `{ turrets, enemies }` |
+
+## Deterministic screenshots — reproducible visual states
+
+For visual debugging you usually want the **exact same game state every time**,
+so a screenshot diff reflects *your code change* and nothing else. Use the
+deterministic trio instead of `startGame()` + a real-time wait:
+
+```
+1. browser_navigate("http://localhost:3000")
+2. browser_evaluate(() => window.__GAME__.isReady())            → expect true
+3. browser_evaluate(() => window.__GAME__.seedRandom(424242))   → seed BEFORE start
+4. browser_evaluate(() => window.__GAME__.startDeterministic()) → start + freeze ticker
+5. browser_evaluate(() => window.__GAME__.freezeStarfield())
+6. browser_evaluate(() => window.__GAME__.setResources(5000))
+7. browser_evaluate(() => window.__GAME__.placeTurret(1, 960, 540))
+8. browser_evaluate(() => window.__GAME__.stepFrames(600))      → advance 10s instantly
+9. browser_take_screenshot({ filename: "verify__wave-in-progress.png" })
+10. browser_console_messages() → expect [] (no errors)
+11. Read the PNG, describe what you saw.
+```
+
+Why this beats a wall-clock wait:
+- **Instant** — `stepFrames(600)` simulates 10 seconds in milliseconds.
+- **Reproducible** — same seed + same frame count = pixel-identical game state.
+  Re-run after a code change and any visual diff is purely your change.
+- **No flake** — no animation mid-capture, no "did enough time pass" guessing.
+
+Caveat: the AI Commander autoplay is on by default and has small residual
+nondeterminism. For a perfectly reproducible state, disable it right after
+`startDeterministic()`:
+`browser_evaluate(() => { if (window.__GAME__.isAIEnabled()) window.__GAME__.toggleAI(); })`.
 
 ## Gotchas (from prior pain)
 

--- a/e2e/fixtures/game.fixture.ts
+++ b/e2e/fixtures/game.fixture.ts
@@ -11,8 +11,11 @@ export interface GameHelpers {
   waitForState(state: string, timeout?: number): Promise<void>;
   waitForEnemies(timeout?: number): Promise<void>;
   startGame(): Promise<void>;
+  startDeterministic(): Promise<void>;
   freezeStarfield(): Promise<void>;
   clickCanvas(worldX: number, worldY: number): Promise<void>;
+  stepFrames(frames: number, deltaMs?: number): Promise<void>;
+  seedRandom(seed: number): Promise<void>;
 }
 
 export const test = base.extend<{ game: GameHelpers }>({
@@ -82,6 +85,12 @@ export const test = base.extend<{ game: GameHelpers }>({
         );
       },
 
+      startDeterministic: async () => {
+        await page.evaluate(
+          () => (window as unknown as { __GAME__: { startDeterministic(): void } }).__GAME__.startDeterministic()
+        );
+      },
+
       freezeStarfield: async () => {
         await page.evaluate(
           () => (window as unknown as { __GAME__: { freezeStarfield(): void } }).__GAME__.freezeStarfield()
@@ -96,6 +105,24 @@ export const test = base.extend<{ game: GameHelpers }>({
         await page.mouse.click(
           box.x + worldX * scaleX,
           box.y + worldY * scaleY
+        );
+      },
+
+      stepFrames: async (frames: number, deltaMs?: number) => {
+        await page.evaluate(
+          ({ frames, deltaMs }) => (window as unknown as {
+            __GAME__: { stepFrames(f: number, d?: number): void }
+          }).__GAME__.stepFrames(frames, deltaMs),
+          { frames, deltaMs }
+        );
+      },
+
+      seedRandom: async (seed: number) => {
+        await page.evaluate(
+          (s) => (window as unknown as {
+            __GAME__: { seedRandom(s: number): void }
+          }).__GAME__.seedRandom(s),
+          seed
         );
       },
     };

--- a/e2e/helpers/game-bridge.ts
+++ b/e2e/helpers/game-bridge.ts
@@ -41,6 +41,8 @@ export interface GameBridge {
   clearEvents(): void;
 
   startGame(): void;
+  /** Start a game with the wall-clock ticker frozen — advance only via stepFrames(). */
+  startDeterministic(): void;
   pause(): void;
   resume(): void;
   restart(): void;
@@ -55,6 +57,11 @@ export interface GameBridge {
   getEntityCounts(): EntityCounts;
 
   freezeStarfield(): void;
+
+  /** Deterministically advance the simulation by N fixed-delta frames. */
+  stepFrames(frames: number, deltaMs?: number): void;
+  /** Seed Math.random with a reproducible PRNG (mulberry32). */
+  seedRandom(seed: number): void;
 
   isReady(): boolean;
 }

--- a/e2e/tests/deterministic-gameplay.spec.ts
+++ b/e2e/tests/deterministic-gameplay.spec.ts
@@ -1,0 +1,152 @@
+import { test, expect } from '../fixtures/game.fixture';
+import type { Page } from '@playwright/test';
+import type { GameHelpers } from '../fixtures/game.fixture';
+import type { GameSnapshot, EntityCounts } from '../helpers/game-bridge';
+
+/**
+ * Deterministic gameplay tests.
+ *
+ * These exercise the game as a player would — start a game, build a turret
+ * defence, survive waves — but use `seedRandom()` + `stepFrames()` so the
+ * simulation is frame-exact and wall-clock independent. A 30-second battle
+ * runs in milliseconds and produces the same result every time, which lets
+ * us assert on exact state instead of loose bounds with generous timeouts.
+ *
+ * The AI Commander autoplay is disabled for the reproducibility tests so the
+ * test harness is the sole actor — its economic micro-decisions still carry
+ * a small residual nondeterminism. The AI path is covered separately by the
+ * "AI Commander" functional test with loose bounds.
+ */
+test.describe('Deterministic Gameplay', () => {
+  test.setTimeout(60000);
+
+  interface RunResult {
+    snapshot: GameSnapshot;
+    counts: EntityCounts;
+  }
+
+  /** The full set of state proven reproducible under a fixed seed. */
+  function deterministicState(run: RunResult) {
+    return {
+      wave: run.snapshot.wave,
+      waveState: run.snapshot.waveState,
+      activeEnemies: run.snapshot.activeEnemies,
+      kmHealth: run.snapshot.kmHealth,
+      kmMaxHealth: run.snapshot.kmMaxHealth,
+      enemiesDefeated: run.snapshot.score.enemiesDefeated,
+      comboCount: run.snapshot.score.comboCount,
+      maxCombo: run.snapshot.score.maxCombo,
+      resources: run.snapshot.resources,
+      turrets: run.counts.turrets,
+      enemies: run.counts.enemies,
+    };
+  }
+
+  /**
+   * Play a full defended battle: seed the RNG, start a game with the wall
+   * clock frozen, disable the AI Commander, build a cardinal ring of torpedo
+   * turrets around the Kobayashi Maru, then advance exactly `frames` frames.
+   */
+  async function playSeededBattle(
+    page: Page,
+    game: GameHelpers,
+    seed: number,
+    frames = 1800,
+  ): Promise<RunResult> {
+    await page.goto('/');
+    await game.waitForGameReady();
+    await game.seedRandom(seed);
+    await game.startDeterministic();
+    await page.evaluate(() => {
+      if (window.__GAME__.isAIEnabled()) window.__GAME__.toggleAI();
+    });
+    await game.waitForState('PLAYING');
+    await game.freezeStarfield();
+    await page.evaluate(() => window.__GAME__.setResources(99999));
+    // Player builds a defensive ring around the KM at (960, 540).
+    await page.evaluate(() => {
+      window.__GAME__.placeTurret(1, 960, 340);
+      window.__GAME__.placeTurret(1, 960, 740);
+      window.__GAME__.placeTurret(1, 660, 540);
+      window.__GAME__.placeTurret(1, 1260, 540);
+    });
+    await game.clearEvents();
+    await game.stepFrames(frames);
+    return { snapshot: await game.getSnapshot(), counts: await game.getEntityCounts() };
+  }
+
+  test('a seeded battle is byte-for-byte reproducible', async ({ page, game }) => {
+    const runA = await playSeededBattle(page, game, 424242);
+    const runB = await playSeededBattle(page, game, 424242);
+    expect(deterministicState(runB)).toEqual(deterministicState(runA));
+  });
+
+  test('different seeds produce different battles', async ({ page, game }) => {
+    const runA = await playSeededBattle(page, game, 1);
+    const runB = await playSeededBattle(page, game, 999999);
+    expect(deterministicState(runB)).not.toEqual(deterministicState(runA));
+  });
+
+  test('player defends the Kobayashi Maru and clears enemies', async ({ page, game }) => {
+    const { snapshot } = await playSeededBattle(page, game, 424242);
+    // The defended KM survives the battle.
+    expect(snapshot.kmHealth).toBeGreaterThan(0);
+    // Turrets actually destroy enemies.
+    expect(snapshot.score.enemiesDefeated).toBeGreaterThan(0);
+    // Waves progress over 30 simulated seconds.
+    expect(snapshot.wave).toBeGreaterThanOrEqual(2);
+  });
+
+  test('enemy-kill events match the score counter', async ({ page, game }) => {
+    const { snapshot } = await playSeededBattle(page, game, 424242);
+    const killEvents = await game.getEventsByType('ENEMY_KILLED');
+    expect(killEvents.length).toBe(snapshot.score.enemiesDefeated);
+  });
+
+  test('god mode keeps the KM at full health through a long battle', async ({ page, game }) => {
+    await page.goto('/');
+    await game.waitForGameReady();
+    await game.seedRandom(31337);
+    await game.startDeterministic();
+    await game.waitForState('PLAYING');
+    await page.evaluate(() => window.__GAME__.toggleGodMode());
+    await game.stepFrames(3600); // 60 simulated seconds, no turrets placed
+    const snapshot = await game.getSnapshot();
+    expect(snapshot.kmHealth).toBe(snapshot.kmMaxHealth);
+  });
+
+  test('stepFrames advances wave progression', async ({ page, game }) => {
+    await page.goto('/');
+    await game.waitForGameReady();
+    await game.seedRandom(100);
+    await game.startDeterministic();
+    await game.waitForState('PLAYING');
+    const before = await game.getSnapshot();
+    await game.stepFrames(900); // 15 simulated seconds
+    const after = await game.getSnapshot();
+    expect(after.wave).toBeGreaterThanOrEqual(before.wave);
+    expect(after.score.timeSurvived).toBeGreaterThan(before.score.timeSurvived);
+  });
+
+  test('the AI Commander autoplays and mounts a defence', async ({ page, game }) => {
+    // AI is enabled by default — let it run and verify it functions.
+    await page.goto('/');
+    await game.waitForGameReady();
+    await game.seedRandom(2024);
+    await game.startDeterministic();
+    await game.waitForState('PLAYING');
+    expect(await page.evaluate(() => window.__GAME__.isAIEnabled())).toBe(true);
+    const before = await game.getEntityCounts();
+    await game.stepFrames(3600); // 60 simulated seconds of autoplay
+    const after = await game.getEntityCounts();
+    // The AI Commander builds turrets to defend the KM.
+    expect(after.turrets).toBeGreaterThan(before.turrets);
+  });
+
+  test('a deterministic battle produces no page errors', async ({ page, game }) => {
+    const errors: string[] = [];
+    page.on('pageerror', (error) => { errors.push(error.message); });
+    await playSeededBattle(page, game, 555);
+    expect(errors).toEqual([]);
+  });
+});

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,6 @@
+# onlyBuiltDependencies — pnpm 10 (CI). allowBuilds — pnpm 11 (local).
+# Both keys kept so the repo installs cleanly on either pnpm major.
 onlyBuiltDependencies:
   - esbuild
+allowBuilds:
+  esbuild: true

--- a/src/__tests__/gameLoopStep.test.ts
+++ b/src/__tests__/gameLoopStep.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Tests for deterministic frame stepping in GameLoopManager.
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// ── Mock pixi.js before importing anything that depends on it ──
+vi.mock('pixi.js', async () => {
+  const { setupPixiMock } = await import('./helpers/mockPixi');
+  return setupPixiMock();
+});
+
+import type { Application } from 'pixi.js';
+import { GameLoopManager } from '../core/loop/GameLoopManager';
+
+function makeMockApp(): Application {
+  return {
+    ticker: { add: vi.fn(), remove: vi.fn(), deltaMS: 16, FPS: 60 },
+  } as unknown as Application;
+}
+
+describe('GameLoopManager.step', () => {
+  let loop: GameLoopManager;
+
+  beforeEach(() => {
+    loop = new GameLoopManager(makeMockApp());
+  });
+
+  it('should run gameplay and physics callbacks once per frame', () => {
+    let gameplay = 0;
+    let physics = 0;
+    loop.onGameplay(() => { gameplay++; });
+    loop.onPhysics(() => { physics++; });
+
+    loop.step(1 / 60, 10);
+
+    expect(gameplay).toBe(10);
+    expect(physics).toBe(10);
+  });
+
+  it('should run render, pre-update and UI callbacks once per frame', () => {
+    let pre = 0;
+    let render = 0;
+    let ui = 0;
+    loop.onPreUpdate(() => { pre++; });
+    loop.onRender(() => { render++; });
+    loop.onUI(() => { ui++; });
+
+    loop.step(1 / 60, 5);
+
+    expect(pre).toBe(5);
+    expect(render).toBe(5);
+    expect(ui).toBe(5);
+  });
+
+  it('should advance game time by the fixed delta each frame', () => {
+    loop.step(0.1, 5);
+    expect(loop.getGameTime()).toBeCloseTo(0.5, 6);
+  });
+
+  it('should pass the fixed delta to callbacks', () => {
+    const deltas: number[] = [];
+    loop.onPhysics((dt) => { deltas.push(dt); });
+
+    loop.step(0.25, 3);
+
+    expect(deltas).toEqual([0.25, 0.25, 0.25]);
+  });
+
+  it('should skip gameplay/physics while paused but still render', () => {
+    let gameplay = 0;
+    let render = 0;
+    loop.onGameplay(() => { gameplay++; });
+    loop.onRender(() => { render++; });
+    loop.pause();
+
+    loop.step(1 / 60, 8);
+
+    expect(gameplay).toBe(0);
+    expect(render).toBe(8);
+    expect(loop.getGameTime()).toBe(0);
+  });
+
+  it('should default to a single frame', () => {
+    let physics = 0;
+    loop.onPhysics(() => { physics++; });
+
+    loop.step(1 / 60);
+
+    expect(physics).toBe(1);
+  });
+});

--- a/src/__tests__/gameplayRng.test.ts
+++ b/src/__tests__/gameplayRng.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for the seeded gameplay RNG.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import {
+  seedGameplayRng,
+  resetGameplayRng,
+  isGameplayRngSeeded,
+  randomFloat,
+} from '../utils/gameplayRng';
+
+describe('gameplayRng', () => {
+  afterEach(() => {
+    // Module-level state — reset so tests do not leak into each other.
+    resetGameplayRng();
+    vi.restoreAllMocks();
+  });
+
+  describe('seed state', () => {
+    it('should report not seeded by default', () => {
+      expect(isGameplayRngSeeded()).toBe(false);
+    });
+
+    it('should report seeded after seedGameplayRng', () => {
+      seedGameplayRng(123);
+      expect(isGameplayRngSeeded()).toBe(true);
+    });
+
+    it('should report not seeded after resetGameplayRng', () => {
+      seedGameplayRng(123);
+      resetGameplayRng();
+      expect(isGameplayRngSeeded()).toBe(false);
+    });
+  });
+
+  describe('unseeded mode', () => {
+    it('should delegate to Math.random when not seeded', () => {
+      const spy = vi.spyOn(Math, 'random').mockReturnValue(0.42);
+      expect(randomFloat()).toBe(0.42);
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return values in [0, 1)', () => {
+      for (let i = 0; i < 100; i++) {
+        const v = randomFloat();
+        expect(v).toBeGreaterThanOrEqual(0);
+        expect(v).toBeLessThan(1);
+      }
+    });
+  });
+
+  describe('seeded mode', () => {
+    it('should return values in [0, 1)', () => {
+      seedGameplayRng(987654);
+      for (let i = 0; i < 100; i++) {
+        const v = randomFloat();
+        expect(v).toBeGreaterThanOrEqual(0);
+        expect(v).toBeLessThan(1);
+      }
+    });
+
+    it('should produce an identical sequence for the same seed', () => {
+      seedGameplayRng(424242);
+      const runA = Array.from({ length: 50 }, () => randomFloat());
+
+      seedGameplayRng(424242);
+      const runB = Array.from({ length: 50 }, () => randomFloat());
+
+      expect(runB).toEqual(runA);
+    });
+
+    it('should produce different sequences for different seeds', () => {
+      seedGameplayRng(1);
+      const runA = Array.from({ length: 50 }, () => randomFloat());
+
+      seedGameplayRng(2);
+      const runB = Array.from({ length: 50 }, () => randomFloat());
+
+      expect(runB).not.toEqual(runA);
+    });
+
+    it('should not call Math.random when seeded', () => {
+      const spy = vi.spyOn(Math, 'random');
+      seedGameplayRng(7);
+      randomFloat();
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('should resume Math.random delegation after reset', () => {
+      seedGameplayRng(7);
+      randomFloat();
+      resetGameplayRng();
+      vi.spyOn(Math, 'random').mockReturnValue(0.99);
+      expect(randomFloat()).toBe(0.99);
+    });
+  });
+});

--- a/src/ai/humanization/AIHumanizer.ts
+++ b/src/ai/humanization/AIHumanizer.ts
@@ -8,6 +8,7 @@
  */
 
 import type { AIAction } from '../types';
+import { randomFloat } from '../../utils';
 
 export interface HumanizationConfig {
     /** Base reaction delay in ms (AI thinks before acting) */
@@ -46,7 +47,7 @@ export class AIHumanizer {
      */
     humanizeAction(action: AIAction, currentTime: number): AIAction | null {
         // Check if we should skip (distraction)
-        if (Math.random() < this.config.skipChance) {
+        if (randomFloat() < this.config.skipChance) {
             return null;
         }
 
@@ -75,7 +76,7 @@ export class AIHumanizer {
      */
     private calculateDelay(): number {
         const base = this.config.reactionDelay;
-        const variation = base * this.config.delayVariation * (Math.random() * 2 - 1);
+        const variation = base * this.config.delayVariation * (randomFloat() * 2 - 1);
         return Math.max(50, base + variation);
     }
 
@@ -86,7 +87,7 @@ export class AIHumanizer {
         const result = { ...action };
 
         // Maybe make suboptimal choice (affects priority, executor can use this)
-        if (Math.random() < this.config.suboptimalChance) {
+        if (randomFloat() < this.config.suboptimalChance) {
             result.priority *= 0.9; // Slightly lower priority
         }
 
@@ -96,8 +97,8 @@ export class AIHumanizer {
             const variation = this.config.positionVariation;
             result.params = {
                 ...params,
-                x: params.x + (Math.random() - 0.5) * variation * 2,
-                y: params.y + (Math.random() - 0.5) * variation * 2,
+                x: params.x + (randomFloat() - 0.5) * variation * 2,
+                y: params.y + (randomFloat() - 0.5) * variation * 2,
             };
         }
 

--- a/src/core/Game.ts
+++ b/src/core/Game.ts
@@ -658,6 +658,17 @@ export class Game {
     return this.loopManager.isPaused();
   }
 
+  /**
+   * Deterministically advance the simulation by N fixed-delta frames.
+   * Stops the wall-clock ticker so E2E tests get frame-exact reproducibility.
+   * @param frames - number of frames to advance
+   * @param deltaMs - per-frame delta in milliseconds (default 1/60s)
+   */
+  stepFrames(frames: number, deltaMs: number = 1000 / 60): void {
+    this.loopManager.stop();
+    this.loopManager.step(deltaMs / 1000, frames);
+  }
+
   // Cheat mode methods (delegate to gameplay manager)
   setGodMode(enabled: boolean): void {
     if (enabled) {

--- a/src/core/loop/GameLoopManager.ts
+++ b/src/core/loop/GameLoopManager.ts
@@ -225,14 +225,34 @@ export class GameLoopManager {
      * Main update loop - called by PixiJS ticker.
      */
     private update(): void {
+        // Calculate delta time in seconds from the wall-clock ticker
+        this.deltaTime = this.app.ticker.deltaMS / 1000;
+        this.tick();
+    }
+
+    /**
+     * Advance the simulation by a fixed number of frames, each with an
+     * identical delta. Bypasses the wall-clock ticker so E2E tests get
+     * reproducible, frame-exact results. Stop the ticker before stepping.
+     * @param deltaSeconds - per-frame delta in seconds
+     * @param frames - number of frames to advance
+     */
+    step(deltaSeconds: number, frames: number = 1): void {
+        for (let i = 0; i < frames; i++) {
+            this.deltaTime = deltaSeconds;
+            this.tick();
+        }
+    }
+
+    /**
+     * Run one frame of all update phases using the current deltaTime.
+     */
+    private tick(): void {
         const services = getServices();
         const perfMon = services.tryGet('performanceMonitor');
 
         // Start frame timing
         perfMon?.startFrame();
-
-        // Calculate delta time in seconds
-        this.deltaTime = this.app.ticker.deltaMS / 1000;
 
         // Phase 1: Pre-update (always runs)
         this.runCallbacks(this.preUpdateCallbacks);

--- a/src/game/spawnPoints.ts
+++ b/src/game/spawnPoints.ts
@@ -4,6 +4,7 @@
  */
 import { GAME_CONFIG } from '../types/constants';
 import { WAVE_CONFIG } from '../config';
+import { randomFloat } from '../utils';
 import { FormationType } from './waveConfig';
 
 /**
@@ -29,7 +30,7 @@ const EDGE_MARGIN = WAVE_CONFIG.SPAWN.EDGE_MARGIN;
  */
 export function getRandomEdge(): EdgeType {
   const edges: EdgeType[] = ['top', 'right', 'bottom', 'left'];
-  return edges[Math.floor(Math.random() * edges.length)];
+  return edges[Math.floor(randomFloat() * edges.length)];
 }
 
 /**
@@ -39,7 +40,7 @@ export function getRandomEdge(): EdgeType {
  * @returns A spawn position
  */
 export function getEdgePosition(edge: EdgeType, positionAlongEdge?: number): SpawnPosition {
-  const pos = positionAlongEdge ?? Math.random();
+  const pos = positionAlongEdge ?? randomFloat();
   const width = GAME_CONFIG.WORLD_WIDTH;
   const height = GAME_CONFIG.WORLD_HEIGHT;
 
@@ -77,8 +78,8 @@ export function getClusterPositions(count: number, clusterRadius: number = WAVE_
 
   for (let i = 0; i < count; i++) {
     // Random offset within cluster radius
-    const angle = Math.random() * Math.PI * 2;
-    const distance = Math.random() * clusterRadius;
+    const angle = randomFloat() * Math.PI * 2;
+    const distance = randomFloat() * clusterRadius;
 
     positions.push({
       x: centerPos.x + Math.cos(angle) * distance,

--- a/src/game/wave/EnemySpawner.ts
+++ b/src/game/wave/EnemySpawner.ts
@@ -11,6 +11,7 @@ import { createEnemy } from '../../ecs/entityFactory';
 import { Velocity } from '../../ecs/components';
 import { GAME_CONFIG } from '../../types/constants';
 import { WAVE_CONFIG } from '../../config';
+import { randomFloat } from '../../utils';
 import type { GameWorld } from '../../ecs/world';
 import type { SpawnPosition } from '../spawnPoints';
 
@@ -49,7 +50,7 @@ export class EnemySpawner {
 
         if (distance > 0) {
             // Speed range: 50-200 pixels per second, scaled by difficulty
-            const baseSpeed = WAVE_CONFIG.ENEMY_SPEED.BASE_MIN + Math.random() * WAVE_CONFIG.ENEMY_SPEED.BASE_RANGE;
+            const baseSpeed = WAVE_CONFIG.ENEMY_SPEED.BASE_MIN + randomFloat() * WAVE_CONFIG.ENEMY_SPEED.BASE_RANGE;
             const speedScale = 1 + (currentWave - 1) * WAVE_CONFIG.ENEMY_SPEED.SCALE_PER_WAVE; // 2% faster per wave
             const speed = baseSpeed * speedScale;
 

--- a/src/game/wave/VariantApplier.ts
+++ b/src/game/wave/VariantApplier.ts
@@ -9,6 +9,7 @@
 
 import { addComponent, hasComponent } from 'bitecs';
 import { WAVE_CONFIG } from '../../config';
+import { randomFloat } from '../../utils';
 import { SpriteManager } from '../../rendering/spriteManager';
 import { EnemyRank, RANK_MULTIPLIERS, ABILITY_CONFIG } from '../../types/constants';
 import { Health, Shield, EnemyVariant, SpecialAbility, SpriteRef, EnemyWeapon } from '../../ecs/components';
@@ -54,7 +55,7 @@ export class VariantApplier {
 
         // Determine elite chance (10% base + 1% per wave)
         const eliteChance = WAVE_CONFIG.ELITE_CHANCE.BASE + (currentWave * WAVE_CONFIG.ELITE_CHANCE.PER_WAVE);
-        const isElite = Math.random() < eliteChance;
+        const isElite = randomFloat() < eliteChance;
 
         if (isElite) {
             this.applyEliteVariant(eid);

--- a/src/systems/abilitySystem.ts
+++ b/src/systems/abilitySystem.ts
@@ -8,6 +8,7 @@ import { AbilityType, ABILITY_CONFIG as ABILITY_TYPE_CONFIG, GAME_CONFIG, Factio
 import type { AbilityTypeId } from '../types/constants';
 import { assertNever } from '../types/utility';
 import { AI_CONFIG, ABILITY_CONFIG } from '../config';
+import { randomFloat } from '../utils';
 import { createEnemy } from '../ecs/entityFactory';
 import type { GameWorld } from '../ecs/world';
 import { ParticleSystem } from '../rendering';
@@ -300,7 +301,7 @@ function processSplitAbility(
 
   const config = ABILITY_TYPE_CONFIG[AbilityType.SPLIT];
   const splitCount = config.splitCount ?
-    config.splitCount.min + Math.floor(Math.random() * (config.splitCount.max - config.splitCount.min + 1)) :
+    config.splitCount.min + Math.floor(randomFloat() * (config.splitCount.max - config.splitCount.min + 1)) :
     2;
 
   for (let i = 0; i < splitCount; i++) {
@@ -360,7 +361,7 @@ function processSummonAbility(
     const faction = Faction.id[entity];
 
     // Spawn reinforcements
-    const summonCount = ABILITY_CONFIG.SUMMON.COUNT.MIN + Math.floor(Math.random() * (ABILITY_CONFIG.SUMMON.COUNT.MAX - ABILITY_CONFIG.SUMMON.COUNT.MIN));
+    const summonCount = ABILITY_CONFIG.SUMMON.COUNT.MIN + Math.floor(randomFloat() * (ABILITY_CONFIG.SUMMON.COUNT.MAX - ABILITY_CONFIG.SUMMON.COUNT.MIN));
 
     for (let i = 0; i < summonCount; i++) {
       const angle = (Math.PI * 2 * i) / summonCount;
@@ -474,8 +475,8 @@ function findSafePosition(spatialHash?: SpatialHash): { x: number; y: number } {
   let attempts = 0;
 
   while (attempts < ABILITY_CONFIG.TELEPORT.MAX_ATTEMPTS) {
-    const x = margin + Math.random() * (GAME_CONFIG.WORLD_WIDTH - margin * 2);
-    const y = margin + Math.random() * (GAME_CONFIG.WORLD_HEIGHT - margin * 2);
+    const x = margin + randomFloat() * (GAME_CONFIG.WORLD_WIDTH - margin * 2);
+    const y = margin + randomFloat() * (GAME_CONFIG.WORLD_HEIGHT - margin * 2);
 
     // Check if far enough from threats
     if (isSafePosition(x, y, safeDistance, spatialHash)) {
@@ -487,8 +488,8 @@ function findSafePosition(spatialHash?: SpatialHash): { x: number; y: number } {
 
   // Fallback: edge of screen
   return {
-    x: Math.random() < 0.5 ? margin : GAME_CONFIG.WORLD_WIDTH - margin,
-    y: Math.random() * GAME_CONFIG.WORLD_HEIGHT
+    x: randomFloat() < 0.5 ? margin : GAME_CONFIG.WORLD_WIDTH - margin,
+    y: randomFloat() * GAME_CONFIG.WORLD_HEIGHT
   };
 }
 

--- a/src/systems/combatSystem.ts
+++ b/src/systems/combatSystem.ts
@@ -6,6 +6,7 @@ import { query, hasComponent, World } from 'bitecs';
 import { Position, Turret, Target, Faction, Health, Shield, WeaponProperties, EnemyVariant } from '../ecs/components';
 import { TurretType, ProjectileType } from '../types/constants';
 import { COMBAT_CONFIG, RENDERING_CONFIG, TURRET_DAMAGE_TYPE, FACTION_RESISTANCES } from '../config';
+import { randomFloat } from '../utils';
 import { createProjectile } from '../ecs/entityFactory';
 import { AudioManager, SoundType } from '../audio';
 import { ParticleSystem, EFFECTS } from '../rendering';
@@ -357,7 +358,7 @@ export class CombatSystem {
       const statusType = WeaponProperties.statusEffectType[turretEid];
       const statusChance = WeaponProperties.statusEffectChance[turretEid];
 
-      if (statusType > 0 && Math.random() < statusChance) {
+      if (statusType > 0 && randomFloat() < statusChance) {
         if (statusType === 1) {
           applyBurning(world, entityId, COMBAT_CONFIG.STATUS_EFFECTS.BURNING.DAMAGE_PER_TICK, COMBAT_CONFIG.STATUS_EFFECTS.BURNING.DURATION);
         } else if (statusType === 2) {

--- a/src/testing/e2eTestBridge.ts
+++ b/src/testing/e2eTestBridge.ts
@@ -13,6 +13,7 @@ import { EventBus } from '../core/EventBus';
 import { GameEventType } from '../types/events';
 import { query } from 'bitecs';
 import { Turret, Health, Shield } from '../ecs/components';
+import { seedGameplayRng } from '../utils/gameplayRng';
 
 interface CapturedEvent {
   type: string;
@@ -67,6 +68,16 @@ export function installTestBridge(game: Game): void {
     clearEvents: () => { events.length = 0; },
 
     startGame: () => game.startGame(),
+
+    // Start a game and immediately freeze the wall-clock ticker, so the
+    // simulation only advances via stepFrames(). This eliminates the variable
+    // number of real-time frames that would otherwise tick between async test
+    // steps — required for frame-exact reproducible E2E runs.
+    startDeterministic: () => {
+      game.startGame();
+      game.stepFrames(0); // stops the ticker, advances zero frames
+    },
+
     pause: () => game.pause(),
     resume: () => game.resume(),
     restart: () => game.restart(),
@@ -100,6 +111,18 @@ export function installTestBridge(game: Game): void {
 
     freezeStarfield: () => {
       getServices().get('starfield').frozen = true;
+    },
+
+    stepFrames: (frames: number, deltaMs?: number) => {
+      game.stepFrames(frames, deltaMs);
+    },
+
+    // Seed the gameplay RNG so the simulation becomes reproducible. Only the
+    // gameplay random stream is affected — rendering and particle randomness
+    // stay on Math.random — so visual effects cannot desync the simulation.
+    // Combine with stepFrames() for frame-exact deterministic runs.
+    seedRandom: (seed: number) => {
+      seedGameplayRng(seed);
     },
 
     isReady: () => true,

--- a/src/utils/gameplayRng.ts
+++ b/src/utils/gameplayRng.ts
@@ -1,0 +1,56 @@
+/**
+ * Seeded gameplay RNG for Kobayashi Maru.
+ *
+ * A single deterministic random stream for all gameplay-affecting randomness
+ * (enemy spawns, speed rolls, variant/elite rolls, ability rolls, status-effect
+ * procs). Kept deliberately SEPARATE from rendering and particle randomness —
+ * those stay on `Math.random()` so visual effects can never desync the
+ * simulation.
+ *
+ * Unseeded, `randomFloat()` falls back to `Math.random()`, so production
+ * behaviour is byte-for-byte unchanged. Calling `seedGameplayRng()` (done by
+ * the E2E test bridge) switches the stream to a deterministic mulberry32 PRNG,
+ * enabling frame-exact reproducible runs when combined with fixed-timestep
+ * stepping.
+ *
+ * @module utils/gameplayRng
+ */
+
+let state: number | null = null;
+
+/**
+ * Seed the gameplay RNG, switching it to deterministic mode.
+ * @param seed - any 32-bit integer
+ */
+export function seedGameplayRng(seed: number): void {
+  state = seed >>> 0;
+}
+
+/**
+ * Clear the seed, reverting to `Math.random()` (production default).
+ */
+export function resetGameplayRng(): void {
+  state = null;
+}
+
+/**
+ * Whether the gameplay RNG is currently in deterministic (seeded) mode.
+ */
+export function isGameplayRngSeeded(): boolean {
+  return state !== null;
+}
+
+/**
+ * Returns a float in [0, 1). Deterministic (mulberry32) when seeded,
+ * otherwise delegates to `Math.random()`.
+ */
+export function randomFloat(): number {
+  if (state === null) {
+    return Math.random();
+  }
+  state = (state + 0x6d2b79f5) >>> 0;
+  let t = state;
+  t = Math.imul(t ^ (t >>> 15), t | 1);
+  t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+  return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,3 +3,4 @@
  * Contains utility data structures and helpers
  */
 export * from './BinaryHeap';
+export * from './gameplayRng';


### PR DESCRIPTION
## Summary

Adds a seeded gameplay RNG and frame-exact loop stepping so E2E tests run **reproducibly without wall-clock waits**. A 30-second battle now simulates in milliseconds and produces byte-identical results every run, enabling exact-state assertions instead of loose bounds with generous timeouts.

## What changed

**Core determinism**
- `src/utils/gameplayRng.ts` — seeded mulberry32 stream. Unseeded, it falls back to `Math.random()`, so production behaviour is byte-for-byte unchanged.
- Gameplay-affecting randomness (enemy spawns, speeds, variant/elite rolls, ability rolls, status-effect procs, AI humanization) routed through `randomFloat()`. Rendering/particle randomness deliberately stays on `Math.random()` so visual effects can never desync the simulation.
- `GameLoopManager.step()` / `Game.stepFrames()` — advance the simulation by N fixed-delta frames, bypassing the wall-clock ticker.

**Test bridge**
- New `window.__GAME__` methods: `seedRandom()`, `stepFrames()`, `startDeterministic()` — wired through the bridge, `game-bridge.ts` types, and the `game.fixture.ts` helpers.

**Tests**
- `e2e/tests/deterministic-gameplay.spec.ts` — 8 user-flow tests: byte-for-byte reproducibility, seed divergence, defended-KM battle, god mode, AI autoplay coverage, no-page-errors.
- `gameplayRng.test.ts` + `gameLoopStep.test.ts` — 16 unit tests.

**Toolchain**
- Node 24 LTS + pnpm 11. `package.json` gains `packageManager` and `engines.node` pins; `pnpm-workspace.yaml` uses `allowBuilds` for esbuild.

**Skills**
- `e2e` and `visual-check` project skills updated with the deterministic workflow.

## Known limitation

The AI Commander autoplay carries small residual nondeterminism in its economic micro-decisions. Core simulation (spawns, combat, kills, health, waves) is fully deterministic; the reproducibility tests disable the AI so the harness is the sole actor, and the AI path is covered separately with loose-bound assertions.

## Test plan

- [x] `pnpm run lint` — clean
- [x] `pnpm run test` — 2646 passed (118 files)
- [x] `pnpm run build` — succeeds
- [x] `pnpm run e2e` — 22 passed (incl. 8 new deterministic + 3 visual)
- [x] Two fresh seeded runs verified byte-identical via browser