### PR TITLE
ci: modernize toolchain to Node 24 LTS and pnpm 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,12 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 10
+          version: 11
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "pnpm"
 
       - name: Install dependencies
@@ -56,12 +56,12 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 10
+          version: 11
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "pnpm"
 
       - name: Install dependencies

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -34,12 +34,12 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 10
+          version: 11
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "pnpm"
 
       - name: Setup Pages


### PR DESCRIPTION
## Summary
- Bump `pnpm/action-setup` pin from `10` to `11` in `ci.yml` and `deploy-pages.yml`
- Bump `node-version` from `20` to `24` (LTS) across both workflows
- Aligns CI with the local development toolchain

## Notes
- Lockfile is `lockfileVersion: 9.0` — compatible with both pnpm 10 and 11
- `pnpm-workspace.yaml` is dual-key (`onlyBuiltDependencies` + `allowBuilds`), so the build-script approval works on either pnpm major version
- No application code changes

## Test plan
- [ ] CI `lint-and-test` job passes on Node 24 / pnpm 11
- [ ] CI `e2e-tests` job runs (non-blocking)
- [ ] Pages deploy build succeeds